### PR TITLE
Add option to split attribution across two lines

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,6 +62,7 @@
           <option value="instagramStory">Instagram Story</option>
           <option value="twitterFB">Twitter/Facebook</option>
         </select>
+        <input type="checkbox" id="splitAttribution">Split attribution over two lines</input><br>
         <input type="checkbox" id="centerElements">Center text</input>
       </div>
       <div class="four columns">
@@ -76,9 +77,9 @@
       </div>
       <div class="four columns">
         <h5>Elements</h5>
-        <input type="checkbox" id="toggleAttribution" checked>Include attribution<br>
-        <input type="checkbox" id="toggleTitle" checked>Include attribution title<br>
-        <input type="checkbox" id="toggleLogo" checked>Include logo<br>
+        <input type="checkbox" id="toggleAttribution" checked>Include attribution</input><br>
+        <input type="checkbox" id="toggleTitle" checked>Include attribution title</input><br>
+        <input type="checkbox" id="toggleLogo" checked>Include logo</input>
       </div>
     </div>
     <div class="row">


### PR DESCRIPTION
## Completed tasks

Closes #13 

## Description of changes

Adds a checkbox in "Formatting" to split the attribution over two lines. This will be useful on the skinnier templates like Instagram posts or stories. It's worth considering making this the only option when text is centered, as it greatly simplifies the logic for text spacing.