### PR TITLE
Add sunrays option

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,10 +69,10 @@
         <h5>Style</h5>
         <select class="u-full-width background" id="backgroundColor">
           <option value="gray">Gray/Yellow</option>
-          <option value="gradient_a">Yellow/Red Gradient</option>
-          <option value="gradient_b">Orange/Purple Gradient</option>
-          <option value="gradient_c">Yellow/Purple Gradient</option>
+          <option value="gradient_a">Orange/Purple Gradient</option>
+          <option value="gradient_b">Yellow/Purple Gradient</option>
         </select>
+        <input type="checkbox" id="includeSunrays">Include sunrays<br>
         <input type="checkbox" id="useWordmark">Use text logo<br>
       </div>
       <div class="four columns">

--- a/script.js
+++ b/script.js
@@ -129,6 +129,8 @@ const render = () => {
   quoteCtx.fillStyle = hasGradient ? gradient : BACKGROUNDS[scheme];
   quoteCtx.fillRect(0, 0, canvas.width, canvas.height);
 
+  // draw sunrays if included
+  let waitForSunrays = includeSunrays;
   if (includeSunrays) {
     const image = new Image();
     image.onload = () => {
@@ -137,10 +139,21 @@ const render = () => {
       const width = canvas.width * 2;
       const height = canvas.height - yPos * 1.3;
       quoteCtx.drawImage(image, xPos, yPos, width, height);
+      // wait until sunrays have been loaded to draw the foreground
+      renderForeground(canvas, quoteCtx, scheme, size);
     }
     image.src = SUNRAYS[0];
+  } else {
+    renderForeground(canvas, quoteCtx, scheme, size);
   }
+}
 
+/*
+ * Separating the foreground rendering from the background means that the
+ * sunrays won't render over the foreground elements. This renders the border,
+ * logo, quote, and attribution.
+ */
+const renderForeground = (canvas, quoteCtx, scheme, size) => {
   // then draw the border over it
   quoteCtx.strokeStyle = PRIMARY[scheme];
   quoteCtx.lineWidth = BORDERS[size];
@@ -164,6 +177,7 @@ const render = () => {
   const LINE_H = FONT_SIZE[size] + 10;
   const MAX_W = canvas.width - MARGINS[size] * 2;
   const MAX_H = canvas.height;
+  const half = canvas.width / 2;
   wrapText(
     quoteCtx,
     "\“" + quote + "\”",

--- a/script.js
+++ b/script.js
@@ -7,23 +7,24 @@ let includeLogo = true;
 let splitAttribution = false;
 let centerElements = false;
 let useWordmark = false;
+let includeSunrays = false;
 
-const PRIMARY = ["#FFDE16", "#33342E", "#E3EDDF", "#33342E"];
+const PRIMARY = ["#FFDE16", "#E3EDDF", "#33342E"];
 const BACKGROUNDS = [
   ["#33342E"],
-  ["#EF4C39", "#FD9014", "#FFDE16"],
   ["#8F0D56", "#EF4C39", "#FD9014"],
   ["#8F0D56", "#EF4C39", "#FD9014", "#FFDE16"]
 ];
+const SUNRAYS = [
+  "sunrays/orange.svg"
+];
 const LOGOS = [
   "logos/logo-yellow.svg",
-  "logos/logo-gray.svg",
   "logos/logo-white.svg",
   "logos/logo-gray.svg"
 ];
 const TEXT_LOGOS = [
   "logos/text-yellow.svg",
-  "logos/text-gray.svg",
   "logos/text-white.svg",
   "logos/text-gray.svg"
 ];
@@ -127,6 +128,18 @@ const render = () => {
   }
   quoteCtx.fillStyle = hasGradient ? gradient : BACKGROUNDS[scheme];
   quoteCtx.fillRect(0, 0, canvas.width, canvas.height);
+
+  if (includeSunrays) {
+    const image = new Image();
+    image.onload = () => {
+      const xPos = 0 - canvas.width / 2;
+      const yPos = 0 - canvas.height / 4;
+      const width = canvas.width * 2;
+      const height = canvas.height - yPos * 1.3;
+      quoteCtx.drawImage(image, xPos, yPos, width, height);
+    }
+    image.src = SUNRAYS[0];
+  }
 
   // then draw the border over it
   quoteCtx.strokeStyle = PRIMARY[scheme];
@@ -296,6 +309,12 @@ document.getElementById("centerElements").addEventListener("click", () => {
 
 // Change selected background/color scheme
 document.getElementById("backgroundColor").addEventListener("change", render);
+
+// Toggle including sunrays
+document.getElementById("includeSunrays").addEventListener("click", () => {
+  includeSunrays = !includeSunrays;
+  render();
+});
 
 // Toggle wordmark
 document.getElementById("useWordmark").addEventListener("click", () => {

--- a/sunrays/orange.svg
+++ b/sunrays/orange.svg
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 24.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 2048 1095" style="enable-background:new 0 0 2048 1095;" xml:space="preserve">
+<style type="text/css">
+	.st0{opacity:0.15;}
+	.st1{fill:#EF4C39;}
+	.st2{fill:#8F0D56;}
+	.st3{fill:#FFDE16;}
+	.st4{fill:#FD9014;}
+	.st5{opacity:0.53;}
+	.st6{clip-path:url(#SVGID_1_);}
+	.st7{filter:url(#Adobe_OpacityMaskFilter);}
+	.st8{clip-path:url(#SVGID_2_);fill:url(#SVGID_4_);}
+	.st9{clip-path:url(#SVGID_2_);mask:url(#SVGID_3_);fill:url(#SVGID_5_);}
+	.st10{filter:url(#Adobe_OpacityMaskFilter_1_);}
+	.st11{clip-path:url(#SVGID_6_);fill:url(#SVGID_8_);}
+	.st12{clip-path:url(#SVGID_6_);mask:url(#SVGID_7_);fill:url(#SVGID_9_);}
+	.st13{filter:url(#Adobe_OpacityMaskFilter_2_);}
+	.st14{clip-path:url(#SVGID_10_);fill:url(#SVGID_12_);}
+	.st15{clip-path:url(#SVGID_10_);mask:url(#SVGID_11_);fill:url(#SVGID_13_);}
+	.st16{filter:url(#Adobe_OpacityMaskFilter_3_);}
+	.st17{clip-path:url(#SVGID_14_);fill:url(#SVGID_16_);}
+	.st18{clip-path:url(#SVGID_14_);mask:url(#SVGID_15_);fill:url(#SVGID_17_);}
+	.st19{filter:url(#Adobe_OpacityMaskFilter_4_);}
+	.st20{clip-path:url(#SVGID_18_);fill:url(#SVGID_20_);}
+	.st21{clip-path:url(#SVGID_18_);mask:url(#SVGID_19_);fill:url(#SVGID_21_);}
+	.st22{filter:url(#Adobe_OpacityMaskFilter_5_);}
+	.st23{clip-path:url(#SVGID_22_);fill:url(#SVGID_24_);}
+	.st24{clip-path:url(#SVGID_22_);mask:url(#SVGID_23_);fill:url(#SVGID_25_);}
+	.st25{filter:url(#Adobe_OpacityMaskFilter_6_);}
+	.st26{clip-path:url(#SVGID_26_);fill:url(#SVGID_28_);}
+	.st27{clip-path:url(#SVGID_26_);mask:url(#SVGID_27_);fill:url(#SVGID_29_);}
+	.st28{filter:url(#Adobe_OpacityMaskFilter_7_);}
+	.st29{clip-path:url(#SVGID_30_);fill:url(#SVGID_32_);}
+	.st30{clip-path:url(#SVGID_30_);mask:url(#SVGID_31_);fill:url(#SVGID_33_);}
+	.st31{filter:url(#Adobe_OpacityMaskFilter_8_);}
+	.st32{clip-path:url(#SVGID_34_);fill:url(#SVGID_36_);}
+	.st33{clip-path:url(#SVGID_34_);mask:url(#SVGID_35_);fill:url(#SVGID_37_);}
+</style>
+<g class="st0">
+	<polygon class="st4" points="957.4,37.9 1024.4,1014.3 1091.4,37.9 	"/>
+	<polygon class="st4" points="706.9,88.5 1024.4,1014.3 836.3,53.8 	"/>
+	<polygon class="st4" points="478.1,202.2 1024.4,1014.3 594.1,135.2 	"/>
+	<polygon class="st4" points="286.5,371.2 1024.4,1014.3 381.3,276.5 	"/>
+	<polygon class="st4" points="145.2,584.1 1024.4,1014.3 212.2,468.1 	"/>
+	<polygon class="st4" points="63.8,826.3 1024.4,1014.3 98.5,696.9 	"/>
+	<polygon class="st4" points="47.9,1081.3 1024.4,1014.3 47.9,947.3 	"/>
+	<polygon class="st4" points="1212.4,53.8 1024.4,1014.3 1341.8,88.5 	"/>
+	<polygon class="st4" points="1454.6,135.2 1024.4,1014.3 1570.6,202.2 	"/>
+	<polygon class="st4" points="1667.5,276.5 1024.4,1014.3 1762.2,371.2 	"/>
+	<polygon class="st4" points="1836.5,468.1 1024.4,1014.3 1903.5,584.1 	"/>
+	<polygon class="st4" points="1950.2,696.9 1024.4,1014.3 1984.9,826.3 	"/>
+	<polygon class="st4" points="1024.4,1014.3 2000.8,1081.3 2000.8,947.3 	"/>
+</g>
+<g class="st5">
+	<g>
+		<defs>
+			<rect id="SVGID_52_" x="-2389.6" y="2.2" width="1916" height="1612.9"/>
+		</defs>
+		<clipPath id="SVGID_1_">
+			<use xlink:href="#SVGID_52_"  style="overflow:visible;"/>
+		</clipPath>
+		<g class="st6">
+			<defs>
+				<polygon id="SVGID_64_" points="-1428.3,1540.3 -473.6,466 -473.6,88 -1438.5,1530.8 				"/>
+			</defs>
+			<clipPath id="SVGID_2_">
+				<use xlink:href="#SVGID_64_"  style="overflow:visible;"/>
+			</clipPath>
+			<defs>
+				<filter id="Adobe_OpacityMaskFilter" filterUnits="userSpaceOnUse" x="-2005.2" y="-288.5" width="2098.2" height="2205.3">
+					<feColorMatrix  type="matrix" values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 1 0"/>
+				</filter>
+			</defs>
+			<mask maskUnits="userSpaceOnUse" x="-2005.2" y="-288.5" width="2098.2" height="2205.3" id="SVGID_3_">
+				<g class="st7">
+					
+						<radialGradient id="SVGID_4_" cx="1305.8777" cy="1857.8444" r="1" gradientTransform="matrix(872.0001 -418.6667 -418.6667 -872.0001 -362338.9688 2168330.75)" gradientUnits="userSpaceOnUse">
+						<stop  offset="0" style="stop-color:#FFFFFF"/>
+						<stop  offset="0.9888" style="stop-color:#1A1A1A"/>
+						<stop  offset="1" style="stop-color:#1A1A1A"/>
+					</radialGradient>
+					<polygon class="st8" points="-2005.2,360.1 -654.4,-288.5 93,1268.2 -1257.8,1916.8 					"/>
+				</g>
+			</mask>
+			
+				<radialGradient id="SVGID_5_" cx="1305.8777" cy="1857.8444" r="1" gradientTransform="matrix(871.9999 -418.6667 -418.6667 -871.9999 -362338.9375 2168330.5)" gradientUnits="userSpaceOnUse">
+				<stop  offset="0" style="stop-color:#FD9014"/>
+				<stop  offset="0.9888" style="stop-color:#FFDE16"/>
+				<stop  offset="1" style="stop-color:#FFDE16"/>
+			</radialGradient>
+			<polygon class="st9" points="-2005.2,360.1 -654.4,-288.5 93,1268.2 -1257.8,1916.8 			"/>
+		</g>
+	</g>
+</g>
+</svg>


### PR DESCRIPTION
## Completed tasks

Closes #5

## Description of changes

This PR adds an option to include sunrays. When testing, I ran into the issue where the sunrays would render above the border because the border would draw before the SVG had been loaded. To handle this, I separated the foreground rendering into its own function, which is called either in the `onload` for the sunrays image or in the `else` block if sunrays aren't included.

I also removed the unneeded yellow/red gradient.

### TODO

Waiting for confirmation from designers about if we should have multiple options for sunrays, or if we just want to stick with one for now. (And if so, which color to use.)
