### PR TITLE
Remove globals to avoid state-saving issues on Firefox

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
         </select>
         <input type="checkbox" id="centerElements">Center text</input><br>
         <input type="checkbox" id="splitAttribution">Split attribution over two lines</input><br>
-        <input type="checkbox" id="insetLogo">Set logo into border</input>
+        <input type="checkbox" id="insetLogo" checked>Set logo into border</input>
       </div>
       <div class="four columns">
         <h5>Style</h5>


### PR DESCRIPTION
## Completed tasks

Closes #23

At the direction of Jules, this also makes it so the inset logo is the default.

## Description of changes

Using global variables was causing issues on Firefox. (See the #23 for a more in-depth explanation of why.) I removed all of the globals aside from `selectedBackgroundImage` which wasn't causing any issues because it's changed just by clicking on the background photos. Instead of reading the global variable when rendering, I changed those methods to check the HTML element directly.
